### PR TITLE
Fixed ram role authorize for encrypted kms.

### DIFF
--- a/acm/client.py
+++ b/acm/client.py
@@ -68,6 +68,9 @@ def _refresh_session_ak_and_sk_patch(self):
 
 
 def _check_session_credential_patch(self):
+    if not hasattr(self, '_expiration'):
+        self._refresh_session_ak_and_sk()
+        return
     expiration = self._expiration if isinstance(self._expiration, (float, int)) \
         else time.mktime(datetime.strptime(self._expiration, "%Y-%m-%dT%H:%M:%SZ").timetuple())
     now = time.mktime(time.gmtime())


### PR DESCRIPTION
Fix to issue
https://github.com/alibaba/acm-sdk-python/issues/16

There was unhandled scenario with missing attribute ._expiration in EcsRamRoleSigner.